### PR TITLE
Adding new dependencies.

### DIFF
--- a/R5ProTestbed.xcodeproj/project.pbxproj
+++ b/R5ProTestbed.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		480C6B931F7BDE7F009E943F /* VideoToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 480C6B921F7BDE7F009E943F /* VideoToolbox.framework */; };
+		480C6B951F7BDE85009E943F /* libbz2.1.0.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 480C6B941F7BDE85009E943F /* libbz2.1.0.tbd */; };
 		481B156D1EB380F20038A187 /* PublishAuthTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481B156C1EB380F20038A187 /* PublishAuthTest.swift */; };
 		481B156F1EB380FE0038A187 /* SubscribeAuthTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481B156E1EB380FE0038A187 /* SubscribeAuthTest.swift */; };
 		481B15761EB390600038A187 /* PublishSendTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481B15741EB390600038A187 /* PublishSendTest.swift */; };
@@ -58,6 +60,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		480C6B921F7BDE7F009E943F /* VideoToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VideoToolbox.framework; path = System/Library/Frameworks/VideoToolbox.framework; sourceTree = SDKROOT; };
+		480C6B941F7BDE85009E943F /* libbz2.1.0.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libbz2.1.0.tbd; path = usr/lib/libbz2.1.0.tbd; sourceTree = SDKROOT; };
 		481B156C1EB380F20038A187 /* PublishAuthTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PublishAuthTest.swift; path = Tests/PublishAuth/PublishAuthTest.swift; sourceTree = "<group>"; };
 		481B156E1EB380FE0038A187 /* SubscribeAuthTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SubscribeAuthTest.swift; path = Tests/SubscribeAuth/SubscribeAuthTest.swift; sourceTree = "<group>"; };
 		481B15741EB390600038A187 /* PublishSendTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PublishSendTest.swift; path = Tests/SubscribeReceiveSend/PublishSendTest.swift; sourceTree = "<group>"; };
@@ -117,6 +121,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				480C6B951F7BDE85009E943F /* libbz2.1.0.tbd in Frameworks */,
+				480C6B931F7BDE7F009E943F /* VideoToolbox.framework in Frameworks */,
 				487CDBC21E6E4401007FC4EA /* libz.tbd in Frameworks */,
 				48DFEDDB1C21C5AB0040B624 /* libstdc++.6.0.9.tbd in Frameworks */,
 				48DFEDD31C21BF370040B624 /* libiconv.2.4.0.tbd in Frameworks */,
@@ -133,6 +139,8 @@
 		487CDBC01E6E4401007FC4EA /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				480C6B941F7BDE85009E943F /* libbz2.1.0.tbd */,
+				480C6B921F7BDE7F009E943F /* VideoToolbox.framework */,
 				487CDBC11E6E4401007FC4EA /* libz.tbd */,
 			);
 			name = Frameworks;


### PR DESCRIPTION
The following are now required for Apps that utilize the iOS SDK:

* libz2.1.0.tbd - Could not add to SDK as only object files can be added as linked frameworks and/or libraries. Used in decode buffer.
* VideoToolbox - Adding to the SDK still throws build dependency issues for applications. Needed for encoding/decoding.

**THIS COMMIT DOES NOT INCLUDE AN UPDATED FRAMEWORK BUILD**