### PR TITLE
Setting initial orientation upon camera attach

### DIFF
--- a/R5ProTestbed/Tests/PublishDeviceOrientation/PublishDeviceOrientationTest.swift
+++ b/R5ProTestbed/Tests/PublishDeviceOrientation/PublishDeviceOrientationTest.swift
@@ -34,7 +34,7 @@ class PublishDeviceOrientationTest: BaseTest {
         // show preview and debug info
         
         self.currentView!.attach(publishStream!)
-        
+        rotated();
         
         self.publishStream!.publish(Testbed.getParameter(param: "stream1") as! String, type: R5RecordTypeLive)
         


### PR DESCRIPTION
The initial orientation was not being relayed to the server, which is responsible to notifying subscribing clients of a broadcast orientation.

As such, starting out in any mode other than `Portrait` was not recognized on the subscribing side.