### PR TITLE
Feature/telephony interrupt rpro 6187

### DIFF
--- a/R5ProTestbed.xcodeproj/project.pbxproj
+++ b/R5ProTestbed.xcodeproj/project.pbxproj
@@ -254,6 +254,7 @@
 				481B156E1EB380FE0038A187 /* SubscribeAuthTest.swift */,
 				92EAA9DA1D0734EA00B2CE46 /* SubscribeAutoReconnectTest.swift */,
 				92A642E4200D416500882600 /* SubscribeBackgroundTest.swift */,
+				480A8795221ED82D00474724 /* SubscribeTelephonyInterruptTest.swift */,
 				92EBEF05212F1B63003B72FB /* SubscriberBandwidthTest.swift */,
 				92EBEF03212F1B59003B72FB /* BandwidthDetectionDownloadOnlyTest.swift */,
 				92EBEF01212F1B4E003B72FB /* BandwidthDetectionTest.swift */,
@@ -267,7 +268,6 @@
 				92CC78081CB6F8DD00CD4352 /* SubscribeTwoStreams.swift */,
 				926794FE1D06199E004B0BCD /* TwoWayTest.swift */,
 				927FA28920EBCD2D00F16228 /* TwoWayStreamManagerTest.swift */,
-				480A8795221ED82D00474724 /* SubscribeTelephonyInterruptTest.swift */,
 			);
 			name = Tests;
 			sourceTree = "<group>";

--- a/R5ProTestbed.xcodeproj/project.pbxproj
+++ b/R5ProTestbed.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		480A8794221EA8A500474724 /* PublishTelephonyInterruptTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 480A8793221EA8A500474724 /* PublishTelephonyInterruptTest.swift */; };
 		480C6B931F7BDE7F009E943F /* VideoToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 480C6B921F7BDE7F009E943F /* VideoToolbox.framework */; };
 		480C6B951F7BDE85009E943F /* libbz2.1.0.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 480C6B941F7BDE85009E943F /* libbz2.1.0.tbd */; };
 		481B156D1EB380F20038A187 /* PublishAuthTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481B156C1EB380F20038A187 /* PublishAuthTest.swift */; };
@@ -70,6 +71,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		480A8793221EA8A500474724 /* PublishTelephonyInterruptTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PublishTelephonyInterruptTest.swift; path = Tests/PublishTelephonyInterrupt/PublishTelephonyInterruptTest.swift; sourceTree = "<group>"; };
 		480C6B921F7BDE7F009E943F /* VideoToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VideoToolbox.framework; path = System/Library/Frameworks/VideoToolbox.framework; sourceTree = SDKROOT; };
 		480C6B941F7BDE85009E943F /* libbz2.1.0.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libbz2.1.0.tbd; path = usr/lib/libbz2.1.0.tbd; sourceTree = SDKROOT; };
 		481B156C1EB380F20038A187 /* PublishAuthTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PublishAuthTest.swift; path = Tests/PublishAuth/PublishAuthTest.swift; sourceTree = "<group>"; };
@@ -262,6 +264,7 @@
 				92CC78081CB6F8DD00CD4352 /* SubscribeTwoStreams.swift */,
 				926794FE1D06199E004B0BCD /* TwoWayTest.swift */,
 				927FA28920EBCD2D00F16228 /* TwoWayStreamManagerTest.swift */,
+				480A8793221EA8A500474724 /* PublishTelephonyInterruptTest.swift */,
 			);
 			name = Tests;
 			sourceTree = "<group>";
@@ -369,6 +372,7 @@
 				48DFEDD51C21C18F0040B624 /* Home.swift in Sources */,
 				92EBEF06212F1B64003B72FB /* SubscriberBandwidthTest.swift in Sources */,
 				926794FD1D061983004B0BCD /* SubscribeRemoteCallTest.swift in Sources */,
+				480A8794221EA8A500474724 /* PublishTelephonyInterruptTest.swift in Sources */,
 				4874D59F1C221B9500A98102 /* AdaptiveBitrateControllerTest.swift in Sources */,
 				48DFEDAC1C21BBC60040B624 /* AppDelegate.swift in Sources */,
 				48DFEDDF1C21EA780040B624 /* Testbed.swift in Sources */,

--- a/R5ProTestbed.xcodeproj/project.pbxproj
+++ b/R5ProTestbed.xcodeproj/project.pbxproj
@@ -231,6 +231,7 @@
 				92A642E2200D40AC00882600 /* PublishAspectTest.swift */,
 				481B156C1EB380F20038A187 /* PublishAuthTest.swift */,
 				9278C9AF2098E1BE00861C79 /* PublishBackgroundTest.swift */,
+				480A8793221EA8A500474724 /* PublishTelephonyInterruptTest.swift */,
 				92EBEF07212F1B6F003B72FB /* BandwidthDetectionUploadOnlyTest.swift */,
 				485345081C23552F00D409F3 /* CameraSwapTest.swift */,
 				92EA19D91CE13717006B3A97 /* PublishCustomSourceTest.swift */,
@@ -264,7 +265,6 @@
 				92CC78081CB6F8DD00CD4352 /* SubscribeTwoStreams.swift */,
 				926794FE1D06199E004B0BCD /* TwoWayTest.swift */,
 				927FA28920EBCD2D00F16228 /* TwoWayStreamManagerTest.swift */,
-				480A8793221EA8A500474724 /* PublishTelephonyInterruptTest.swift */,
 			);
 			name = Tests;
 			sourceTree = "<group>";

--- a/R5ProTestbed.xcodeproj/project.pbxproj
+++ b/R5ProTestbed.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		480A8794221EA8A500474724 /* PublishTelephonyInterruptTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 480A8793221EA8A500474724 /* PublishTelephonyInterruptTest.swift */; };
+		480A8796221ED82D00474724 /* SubscribeTelephonyInterruptTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 480A8795221ED82D00474724 /* SubscribeTelephonyInterruptTest.swift */; };
 		480C6B931F7BDE7F009E943F /* VideoToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 480C6B921F7BDE7F009E943F /* VideoToolbox.framework */; };
 		480C6B951F7BDE85009E943F /* libbz2.1.0.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 480C6B941F7BDE85009E943F /* libbz2.1.0.tbd */; };
 		481B156D1EB380F20038A187 /* PublishAuthTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481B156C1EB380F20038A187 /* PublishAuthTest.swift */; };
@@ -72,6 +73,7 @@
 
 /* Begin PBXFileReference section */
 		480A8793221EA8A500474724 /* PublishTelephonyInterruptTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PublishTelephonyInterruptTest.swift; path = Tests/PublishTelephonyInterrupt/PublishTelephonyInterruptTest.swift; sourceTree = "<group>"; };
+		480A8795221ED82D00474724 /* SubscribeTelephonyInterruptTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SubscribeTelephonyInterruptTest.swift; path = Tests/SubscribeTelephonyInterrupt/SubscribeTelephonyInterruptTest.swift; sourceTree = "<group>"; };
 		480C6B921F7BDE7F009E943F /* VideoToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VideoToolbox.framework; path = System/Library/Frameworks/VideoToolbox.framework; sourceTree = SDKROOT; };
 		480C6B941F7BDE85009E943F /* libbz2.1.0.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libbz2.1.0.tbd; path = usr/lib/libbz2.1.0.tbd; sourceTree = SDKROOT; };
 		481B156C1EB380F20038A187 /* PublishAuthTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PublishAuthTest.swift; path = Tests/PublishAuth/PublishAuthTest.swift; sourceTree = "<group>"; };
@@ -265,6 +267,7 @@
 				92CC78081CB6F8DD00CD4352 /* SubscribeTwoStreams.swift */,
 				926794FE1D06199E004B0BCD /* TwoWayTest.swift */,
 				927FA28920EBCD2D00F16228 /* TwoWayStreamManagerTest.swift */,
+				480A8795221ED82D00474724 /* SubscribeTelephonyInterruptTest.swift */,
 			);
 			name = Tests;
 			sourceTree = "<group>";
@@ -380,6 +383,7 @@
 				48BF80AE1C245AA7000E996E /* PublishOrientationTest.swift in Sources */,
 				92EA19DD1CE137DD006B3A97 /* CustomVideoSource.swift in Sources */,
 				92EBEF08212F1B6F003B72FB /* BandwidthDetectionUploadOnlyTest.swift in Sources */,
+				480A8796221ED82D00474724 /* SubscribeTelephonyInterruptTest.swift in Sources */,
 				9278C9AC2098B09300861C79 /* SubscribeAudioDelayTest.swift in Sources */,
 				926794FB1D061968004B0BCD /* SubscribeCluster.swift in Sources */,
 				927FA28A20EBCD2D00F16228 /* TwoWayStreamManagerTest.swift in Sources */,

--- a/R5ProTestbed/Tests/AdaptiveBitrate/README.md
+++ b/R5ProTestbed/Tests/AdaptiveBitrate/README.md
@@ -1,12 +1,12 @@
-#Adaptive Bitrate Publishing
+# Adaptive Bitrate Publishing
 
 This example demonstrates the AdaptiveBitrateController, which provides a mechanism to dynamically adjust the video publishing bitrate to adjust quality to meet the bandwidth restrictions of the network connection or encoding hardware.
 
-###Example Code
+### Example Code
 - ***[BaseTest.swift](../BaseTest.swift)***
 - ***[AdaptiveBitrateControllerTest.swift](AdaptiveBitrateControllerTest.swift)***
 
-###Setup
+### Setup
 The AdaptiveBitrateController is easy to set up.  You simply create a new instance of the controller and attach the stream you wish to control.  It will monitor the stream and make all adjustments automatically for you.
 
 

--- a/R5ProTestbed/Tests/PublishBackground/README.md
+++ b/R5ProTestbed/Tests/PublishBackground/README.md
@@ -1,25 +1,29 @@
-#Background Publishing
+# Background Publishing
 
 The Red5Pro SDK is capable of running in the background, allowing people to multitask without needing to disconnect from their stream.
 
-###Example Code
+### Example Code
+
 - ***[BaseTest.swift](../BaseTest.swift)***
 - ***[PublishBackgroundTest.swift](PublishBackgroundTest.swift)***
 
-##Running the example
+## Running the example
+
 Note that closing the app won't disconnect the stream - as that's the point of the example. In order to end the stream, either the example needs to be closed by tapping the "Tests" link in the navigation bar at the top of the view, or the app needs to be closed completely by removing it from the active apps list.
 
-##Permissions
+## Permissions
+
 By default, when an app loses focus, it's moved into the background only temporarily before being suspended completely. In order to prevent this, the app needs to implement the correct permissions to signify to iOS that it will have more processing to do. This permission can be added in the Capabilities tab of the project editor - specifically the `Background Modes` and its sub permission `Audio`. If editing `info.plist` manually, the `UIBackgroundModes` key needs to be added, with an array that contains the string `audio`.
 
 Note - in general iOS does not permit background graphics processing. Attempts to run video in the background will throw warnings, and after enough warning and app that continues to attempt graphics processes in the background may be forcibly suspended.
 
-##Disabling Graphics Processing
+## Disabling Graphics Processing
+
 iOS doesn't send data from the camera to background apps, so most of the work in preventing app culling is done for you. Do note that if you're using a custom video source, you'll need to disable it explicitly. To continue sending audio data without interruption from suddenly having no audio data, the R5Stream property `pauseVideo` needs to be set to true when the app is about to enter the background, and then set to false when it returns to the foreground to continue handling video.
 
 The test needs to add observers to be notified of these state changes, preferably in ViewDidAppear with the creation of the subscriber:
-```
-Swift
+
+```Swift
 	NotificationCenter.default.addObserver(self, selector: #selector(willResignActive), name: .UIApplicationWillResignActive, object: nil)
   NotificationCenter.default.addObserver(self, selector: #selector(willEnterForeground), name: .UIApplicationWillEnterForeground, object: nil)
 }
@@ -33,8 +37,8 @@ override func closeTest() {
   NotificationCenter.default.removeObserver(self)
   super.closeTest()
 ```
-<sub>
+
 [SubscribeBackgroundTest.swift #22](SubscribeBackgroundTest.swift#L22)
-</sub>
+
 
 Also be sure to remove the observers when closing the stream so that the object doesn't continue to listen to events and can be correctly garbage collected.

--- a/R5ProTestbed/Tests/PublishTelephonyInterrupt/PublishTelephonyInterruptTest.swift
+++ b/R5ProTestbed/Tests/PublishTelephonyInterrupt/PublishTelephonyInterruptTest.swift
@@ -12,21 +12,80 @@ import R5Streaming
 @objc(PublishTelephonyInterruptTest)
 class PublishTelephonyInterruptTest: PublishTest {
     
+    var tap : UITapGestureRecognizer? = nil
+    var hasReturnedToForeground = false
+    
+    override func onR5StreamStatus(_ stream: R5Stream!, withStatus statusCode: Int32, withMessage msg: String!) {
+        
+        NSLog("Status: %s ", r5_string_for_status(statusCode))
+        let s =  String(format: "Status: %s (%@)",  r5_string_for_status(statusCode), msg)
+        ALToastView.toast(in: self.view, withText:s)
+        
+        if (Int(statusCode) == Int(r5_status_disconnected.rawValue)) {
+            self.cleanup()
+        }
+    }
+    
     override func viewDidAppear(_ animated: Bool) {
         
         super.viewDidAppear(animated)
         shouldClose = false;
         
         NotificationCenter.default.addObserver(self, selector: #selector(willResignActive), name: .UIApplicationWillResignActive, object: nil)
+        // Normal return from background.
         NotificationCenter.default.addObserver(self, selector: #selector(willEnterForeground), name: .UIApplicationWillEnterForeground, object: nil)
+        // Return from interrupt.
+        NotificationCenter.default.addObserver(self, selector: #selector(didBecomeActive), name: .UIApplicationDidBecomeActive, object: nil)
+        
     }
     
     @objc func willResignActive(_ notification: Notification) {
         publishStream?.pauseVideo = true
+        
+        self.tap = UITapGestureRecognizer(target: self, action: #selector(PublishSendTest.handleSingleTap(recognizer:)))
+        self.view.addGestureRecognizer(self.tap!)
     }
     
     @objc func willEnterForeground(_ notification: Notification) {
         publishStream?.pauseVideo = false
+        
+        hasReturnedToForeground = true
+        if (tap != nil) {
+            self.view.removeGestureRecognizer(self.tap!)
+            tap = nil
+        }
+    }
+    
+    @objc func didBecomeActive(_ notification: Notification) {
+        if (publishStream != nil && !hasReturnedToForeground) {
+            let streamName = Testbed.getParameter(param: "stream1") as? String
+            publishStream?.send("publisherInterrupt", withParam: "streamName=\(streamName)")
+            publishStream?.stop()
+        }
+        hasReturnedToForeground = false
+        
+        if (tap != nil) {
+            ALToastView.toast(in: self.view, withText:"Tap to Re-Publish!")
+        }
+    }
+    
+    func republish () {
+        // Set up the configuration
+        let config = getConfig()
+        // Set up the connection and stream
+        let connection = R5Connection(config: config)
+        
+        setupPublisher(connection: connection!)
+        self.currentView!.attach(publishStream!)
+        self.publishStream!.publish(Testbed.getParameter(param: "stream1") as! String, type: R5RecordTypeLive)
+    }
+    
+    func handleSingleTap(recognizer : UITapGestureRecognizer) {
+        if (self.tap != nil) {
+            self.view.removeGestureRecognizer(self.tap!)
+            tap = nil
+        }
+        republish()
     }
     
     override func closeTest() {

--- a/R5ProTestbed/Tests/PublishTelephonyInterrupt/PublishTelephonyInterruptTest.swift
+++ b/R5ProTestbed/Tests/PublishTelephonyInterrupt/PublishTelephonyInterruptTest.swift
@@ -1,0 +1,39 @@
+//
+//  PublishTelephonyInterruptTest.swift
+//  R5ProTestbed
+//
+//  Created by Todd Anderson on 21/02/2019.
+//  Copyright © 2019 Infrared5. All rights reserved.
+//
+
+import UIKit
+import R5Streaming
+
+@objc(PublishTelephonyInterruptTest)
+class PublishTelephonyInterruptTest: PublishTest {
+    
+    override func viewDidAppear(_ animated: Bool) {
+        
+        super.viewDidAppear(animated)
+        shouldClose = false;
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(willResignActive), name: .UIApplicationWillResignActive, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(willEnterForeground), name: .UIApplicationWillEnterForeground, object: nil)
+    }
+    
+    @objc func willResignActive(_ notification: Notification) {
+        publishStream?.pauseVideo = true
+    }
+    
+    @objc func willEnterForeground(_ notification: Notification) {
+        publishStream?.pauseVideo = false
+    }
+    
+    override func closeTest() {
+        NotificationCenter.default.removeObserver(self)
+        super.closeTest()
+    }
+    
+}
+
+

--- a/R5ProTestbed/Tests/PublishTelephonyInterrupt/PublishTelephonyInterruptTest.swift
+++ b/R5ProTestbed/Tests/PublishTelephonyInterrupt/PublishTelephonyInterruptTest.swift
@@ -42,12 +42,18 @@ class PublishTelephonyInterruptTest: PublishTest {
     @objc func willResignActive(_ notification: Notification) {
         publishStream?.pauseVideo = true
         
+        let streamName = Testbed.getParameter(param: "stream1") as? String
+        publishStream?.send("publisherBackground", withParam: "streamName=\(streamName)")
+        
         self.tap = UITapGestureRecognizer(target: self, action: #selector(PublishSendTest.handleSingleTap(recognizer:)))
         self.view.addGestureRecognizer(self.tap!)
     }
     
     @objc func willEnterForeground(_ notification: Notification) {
         publishStream?.pauseVideo = false
+        
+        let streamName = Testbed.getParameter(param: "stream1") as? String
+        publishStream?.send("publisherForeground", withParam: "streamName=\(streamName)")
         
         hasReturnedToForeground = true
         if (tap != nil) {

--- a/R5ProTestbed/Tests/PublishTelephonyInterrupt/README.md
+++ b/R5ProTestbed/Tests/PublishTelephonyInterrupt/README.md
@@ -1,0 +1,162 @@
+# Handling Interrupts while Publishing
+
+During an interrupt - such as receiving a phone call - of an application that is publishing a stream, the Operating System may reclaim the media devices used in broadcasting. This means that the Camera and/or Microphone will be disconnected from the broadcast the publishing session halting abruptly - leaving your subscribers wonderign what happened.
+
+Though the Red5 Pro SDK cannot stop the Operating System from assuming control in such occurances, we can handle such interruption more gracefully by communicating with subscribers and publishers that interruptions have occurred.
+
+This example - and its paired [SubscribeTelephonyInterruptTest](../SubscribeTelephonyInterrupt/SubscribeTelephonyInterruptTest.swift) test - demonstrate how to handle such interruptions gracefully.
+
+> These examples differ from the [Background](../PublishBackgronud) examples. The **Background Examples** demonstrate how to gracefully handle publishing and subscribing when the application is placed in the background by an explicit User Action - such as hitting the *Home* button. 
+
+## Example Code
+
+- ***[BaseTest.swift](../BaseTest.swift)***
+- ***[PublishTelephonyInterruptTest.swift](PublishTelephonyInterruptTest.swift)***
+- ***[SubscribeTelephonyInterruptTest.swift](../SubscribeTelephonyInterrupt/SubscribeTelephonyInterruptTest.swift)***
+
+# Running the example
+
+The Publishing example works by listening for interrupt and active notifications to recognize when to stop a broadcast and to alert the Publisher that they can beging the broadcast again after interruption, while also sending out notifications to subscribers about its current status.
+
+The Suscribing example works by responding to Publisher notifications and starting a reconnection loop once it is recognizes that the Publisher's broadcast has been halted.
+
+## Testing
+
+1. Launch the `streaming-ios` app onto two iOS devices.
+2. Use one to become the publisher and choose the `Publish - Telephony Interrupt` test to begin a broadcast.
+3. On the other device, choose the `Subscribe - Telephony Interrupt` test to begin playback.
+4. Interrupt the broadcaster by sending a phone call, FaceTime request, etc.
+5. Either accept or decline the interrupt and return to Publisher back to the app.
+6. Tap on the Publisher screen to start the broadcast again.
+
+# Publisher
+
+## Responding to Publisher App state
+
+The Publisher responds to notifications to in order to send notifications to subscribers and respond to interrupts:
+
+```Swift
+NotificationCenter.default.addObserver(self, selector: #selector(willResignActive), name: .UIApplicationWillResignActive, object: nil)
+NotificationCenter.default.addObserver(self, selector: #selector(willEnterForeground), name: .UIApplicationWillEnterForeground, object: nil)
+NotificationCenter.default.addObserver(self, selector: #selector(didBecomeActive), name: .UIApplicationDidBecomeActive, object: nil)}
+```
+
+[PublishTelephonyInterruptTest.swift #34](PublishTelephonyInterruptTest.swift#L34)
+
+When the app is resigned from being active, a `tap` gesture is added:
+
+```Swift
+@objc func willResignActive(_ notification: Notification) {
+    publishStream?.pauseVideo = true
+
+    let streamName = Testbed.getParameter(param: "stream1") as? String
+    publishStream?.send("publisherBackground", withParam: "streamName=\(streamName)")
+        
+    self.tap = UITapGestureRecognizer(target: self, action: #selector(PublishSendTest.handleSingleTap(recognizer:)))
+    self.view.addGestureRecognizer(self.tap!)
+}
+```
+
+[PublishTelephonyInterruptTest.swift #42](PublishTelephonyInterruptTest.swift#L42)
+
+The `tap` gesture will handle re-establishing a broadcast session. However, if the app is returned to the foreground normally - as in the case of hitting the *Home* button once, and then again - then the `tap` gesture handle is removed:
+
+```Swift
+@objc func willEnterForeground(_ notification: Notification) {
+  publishStream?.pauseVideo = false
+
+  let streamName = Testbed.getParameter(param: "stream1") as? String
+  publishStream?.send("publisherForeground", withParam: "streamName=\(streamName)")
+
+  hasReturnedToForeground = true
+  if (tap != nil) {
+      self.view.removeGestureRecognizer(self.tap!)
+      tap = nil
+  }
+}
+```
+
+[PublishTelephonyInterruptTest.swift #52](PublishTelephonyInterruptTest.swift#L52)
+
+If the app has not returned to foreground, and instead has been made active again, the `tap` gesture handle remains - allowing the Publisher to start the broadcast again. Returning to being active without being brought back to the foreground in most cases means that the user (a.k.a., Publisher) was interrupted without the app being put into the background - such as in the case of receiving and declining a phone call.
+
+In the `active` notification response, the broadcast is disconnected as we have most likely lost our media stream due to the interrupt.
+
+```Swift
+@objc func didBecomeActive(_ notification: Notification) {
+  if (publishStream != nil && !hasReturnedToForeground) {
+      let streamName = Testbed.getParameter(param: "stream1") as? String
+      publishStream?.send("publisherInterrupt", withParam: "streamName=\(streamName)")
+      publishStream?.stop()
+  }
+  hasReturnedToForeground = false
+
+  if (tap != nil) {
+      ALToastView.toast(in: self.view, withText:"Tap to Re-Publish!")
+  }
+}
+```
+
+[PublishTelephonyInterruptTest.swift #65](PublishTelephonyInterruptTest.swift#L65)
+
+Upon tap of the screen from such a state, the stream can be re-published - allowing any subscribers to begin playback of the new stream:
+
+```Swift
+func republish () {
+  // Set up the configuration
+  let config = getConfig()
+  // Set up the connection and stream
+  let connection = R5Connection(config: config)
+
+  setupPublisher(connection: connection!)
+  self.currentView!.attach(publishStream!)
+  self.publishStream!.publish(Testbed.getParameter(param: "stream1") as! String, type: R5RecordTypeLive)
+}
+```
+
+[PublishTelephonyInterruptTest.swift #78](PublishTelephonyInterruptTest.swift#L78)
+
+# Subscriber
+
+## Responding to Publisher Notifications
+
+On the Subscriber side, notifications from the Publisher are received to recognize the broadcast state and handle server events appropriately. The `publisherBackground` and `publisherForeground` events are sent from the Publisher using the *Send API*:
+
+```Swift
+func publisherBackground(msg: String) {
+  NSLog("(publisherBackground) the msg: %@", msg)
+  publisherIsInBackground = true
+  ALToastView.toast(in: self.view, withText:"Publish Background")
+}
+
+func publisherForeground(msg: String) {
+  NSLog("(publisherForeground) the msg: %@", msg)
+  publisherIsInBackground = false
+  ALToastView.toast(in: self.view, withText:"Publisher Foreground")
+}
+```
+
+[SubscribeTelephonyInterruptTest.swift #61](../SubscribeTelephonyInterrupt/SubscribeTelephonyInterruptTest.swift#L61)
+
+When a `NetStatus` event notification for `Unpublish` is received and the subscriber is awar of the Publisher having been placed in the background, then it can be determined that an interrupt and disconnect of broadcast has occurred.
+
+At such a state, the Subscriber can begin a reconnect sequence to begin subscribing to the new stream once the Publisher has returned from an interrupt with a new broadcast session:
+
+```Swift
+// publisher has unpublished. possibly from background/interrupt.
+if (publisherIsInBackground) {
+  publisherIsDisconnected = true
+  // Begin reconnect sequence...
+  let view = currentView
+  DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+    if(self.subscribeStream != nil) {
+        view?.attach(nil)
+        self.subscribeStream?.delegate = nil;
+        self.subscribeStream!.stop()
+    }
+    self.reconnect()
+  }
+}
+```
+
+[SubscribeTelephonyInterruptTest.swift #29](../SubscribeTelephonyInterrupt/SubscribeTelephonyInterruptTest.swift#L29)

--- a/R5ProTestbed/Tests/SubscribeBackground/README.md
+++ b/R5ProTestbed/Tests/SubscribeBackground/README.md
@@ -1,22 +1,26 @@
-#Background Subscribing
+# Background Subscribing
 
 The Red5Pro SDK is capable of running in the background, allowing people to multitask without needing to disconnect from their stream.
 
-###Example Code
+### Example Code
+
 - ***[BaseTest.swift](../BaseTest.swift)***
 - ***[SubscribeBackgroundTest.swift](SubscribeBackgroundTest.swift)***
 
-##Running the example
+## Running the example
+
 Begin by publishing to **stream1** from a second device.  **stream1** is the default stream1 name that is used by this example.
 
 Note that closing the app won't disconnect the stream - as that's the point of the example. In order to end the stream, either the example needs to be closed by tapping the "Tests" link in the navigation bar at the top of the view, or the app needs to be closed completely by removing it from the active apps list.
 
-##Permissions
+## Permissions
+
 By default, when an app loses focus, it's moved into the background only temporarily before being suspended completely. In order to prevent this, the app needs to implement the correct permissions to signify to iOS that it will have more processing to do. This permission can be added in the Capabilities tab of the project editor - specifically the `Background Modes` and its sub permission `Audio`. If editing `info.plist` manually, the `UIBackgroundModes` key needs to be added, with an array that contains the string `audio`.
 
 Note - in general iOS does not permit background graphics processing. Attempts to run video in the background will throw warnings, and after enough warning and app that continues to attempt graphics processes in the background may be forcibly suspended.
 
-##Disabling Graphics Processing
+## Disabling Graphics Processing
+
 To prevent app culling, the functions `pauseRender` and `resumeRender` have been added to the R5VideoViewController. These need to be called when the app is about to enter the background and when it returns to the foreground, respectively.
 
 The test needs to add observers to be notified of these state changes, preferably in ViewDidAppear with the creation of the subscriber:

--- a/R5ProTestbed/Tests/SubscribeTelephonyInterrupt/README.md
+++ b/R5ProTestbed/Tests/SubscribeTelephonyInterrupt/README.md
@@ -1,0 +1,162 @@
+# Handling Interrupts while Publishing
+
+During an interrupt - such as receiving a phone call - of an application that is publishing a stream, the Operating System may reclaim the media devices used in broadcasting. This means that the Camera and/or Microphone will be disconnected from the broadcast the publishing session halting abruptly - leaving your subscribers wonderign what happened.
+
+Though the Red5 Pro SDK cannot stop the Operating System from assuming control in such occurances, we can handle such interruption more gracefully by communicating with subscribers and publishers that interruptions have occurred.
+
+This example - and its paired [PublishTelephonyInterruptTest](../PublishTelephonyInterrupt/PublishTelephonyInterruptTest.swift) test - demonstrate how to handle such interruptions gracefully.
+
+> These examples differ from the [Background](../PublishBackgronud) examples. The **Background Examples** demonstrate how to gracefully handle publishing and subscribing when the application is placed in the background by an explicit User Action - such as hitting the *Home* button. 
+
+## Example Code
+
+- ***[BaseTest.swift](../BaseTest.swift)***
+- ***[PublishTelephonyInterruptTest.swift](../PublishTelephonyInterrupt/PublishTelephonyInterruptTest.swift)***
+- ***[SubscribeTelephonyInterruptTest.swift](SubscribeTelephonyInterruptTest.swift)***
+
+# Running the example
+
+The Publishing example works by listening for interrupt and active notifications to recognize when to stop a broadcast and to alert the Publisher that they can beging the broadcast again after interruption, while also sending out notifications to subscribers about its current status.
+
+The Suscribing example works by responding to Publisher notifications and starting a reconnection loop once it is recognizes that the Publisher's broadcast has been halted.
+
+## Testing
+
+1. Launch the `streaming-ios` app onto two iOS devices.
+2. Use one to become the publisher and choose the `Publish - Telephony Interrupt` test to begin a broadcast.
+3. On the other device, choose the `Subscribe - Telephony Interrupt` test to begin playback.
+4. Interrupt the broadcaster by sending a phone call, FaceTime request, etc.
+5. Either accept or decline the interrupt and return to Publisher back to the app.
+6. Tap on the Publisher screen to start the broadcast again.
+
+# Publisher
+
+## Responding to Publisher App state
+
+The Publisher responds to notifications to in order to send notifications to subscribers and respond to interrupts:
+
+```Swift
+NotificationCenter.default.addObserver(self, selector: #selector(willResignActive), name: .UIApplicationWillResignActive, object: nil)
+NotificationCenter.default.addObserver(self, selector: #selector(willEnterForeground), name: .UIApplicationWillEnterForeground, object: nil)
+NotificationCenter.default.addObserver(self, selector: #selector(didBecomeActive), name: .UIApplicationDidBecomeActive, object: nil)}
+```
+
+[PublishTelephonyInterruptTest.swift #34](../PublishTelephonyInterrupt/PublishTelephonyInterruptTest.swift#L34)
+
+When the app is resigned from being active, a `tap` gesture is added:
+
+```Swift
+@objc func willResignActive(_ notification: Notification) {
+    publishStream?.pauseVideo = true
+
+    let streamName = Testbed.getParameter(param: "stream1") as? String
+    publishStream?.send("publisherBackground", withParam: "streamName=\(streamName)")
+        
+    self.tap = UITapGestureRecognizer(target: self, action: #selector(PublishSendTest.handleSingleTap(recognizer:)))
+    self.view.addGestureRecognizer(self.tap!)
+}
+```
+
+[PublishTelephonyInterruptTest.swift #42](../PublishTelephonyInterrupt/PublishTelephonyInterruptTest.swift#L42)
+
+The `tap` gesture will handle re-establishing a broadcast session. However, if the app is returned to the foreground normally - as in the case of hitting the *Home* button once, and then again - then the `tap` gesture handle is removed:
+
+```Swift
+@objc func willEnterForeground(_ notification: Notification) {
+  publishStream?.pauseVideo = false
+
+  let streamName = Testbed.getParameter(param: "stream1") as? String
+  publishStream?.send("publisherForeground", withParam: "streamName=\(streamName)")
+
+  hasReturnedToForeground = true
+  if (tap != nil) {
+      self.view.removeGestureRecognizer(self.tap!)
+      tap = nil
+  }
+}
+```
+
+[PublishTelephonyInterruptTest.swift #52](../PublishTelephonyInterrupt/PublishTelephonyInterruptTest.swift#L52)
+
+If the app has not returned to foreground, and instead has been made active again, the `tap` gesture handle remains - allowing the Publisher to start the broadcast again. Returning to being active without being brought back to the foreground in most cases means that the user (a.k.a., Publisher) was interrupted without the app being put into the background - such as in the case of receiving and declining a phone call.
+
+In the `active` notification response, the broadcast is disconnected as we have most likely lost our media stream due to the interrupt.
+
+```Swift
+@objc func didBecomeActive(_ notification: Notification) {
+  if (publishStream != nil && !hasReturnedToForeground) {
+      let streamName = Testbed.getParameter(param: "stream1") as? String
+      publishStream?.send("publisherInterrupt", withParam: "streamName=\(streamName)")
+      publishStream?.stop()
+  }
+  hasReturnedToForeground = false
+
+  if (tap != nil) {
+      ALToastView.toast(in: self.view, withText:"Tap to Re-Publish!")
+  }
+}
+```
+
+[PublishTelephonyInterruptTest.swift #65](../PublishTelephonyInterrupt/PublishTelephonyInterruptTest.swift#L65)
+
+Upon tap of the screen from such a state, the stream can be re-published - allowing any subscribers to begin playback of the new stream:
+
+```Swift
+func republish () {
+  // Set up the configuration
+  let config = getConfig()
+  // Set up the connection and stream
+  let connection = R5Connection(config: config)
+
+  setupPublisher(connection: connection!)
+  self.currentView!.attach(publishStream!)
+  self.publishStream!.publish(Testbed.getParameter(param: "stream1") as! String, type: R5RecordTypeLive)
+}
+```
+
+[PublishTelephonyInterruptTest.swift #78](../PublishTelephonyInterrupt/PublishTelephonyInterruptTest.swift#L78)
+
+# Subscriber
+
+## Responding to Publisher Notifications
+
+On the Subscriber side, notifications from the Publisher are received to recognize the broadcast state and handle server events appropriately. The `publisherBackground` and `publisherForeground` events are sent from the Publisher using the *Send API*:
+
+```Swift
+func publisherBackground(msg: String) {
+  NSLog("(publisherBackground) the msg: %@", msg)
+  publisherIsInBackground = true
+  ALToastView.toast(in: self.view, withText:"Publish Background")
+}
+
+func publisherForeground(msg: String) {
+  NSLog("(publisherForeground) the msg: %@", msg)
+  publisherIsInBackground = false
+  ALToastView.toast(in: self.view, withText:"Publisher Foreground")
+}
+```
+
+[SubscribeTelephonyInterruptTest.swift #61](SubscribeTelephonyInterruptTest.swift#L61)
+
+When a `NetStatus` event notification for `Unpublish` is received and the subscriber is awar of the Publisher having been placed in the background, then it can be determined that an interrupt and disconnect of broadcast has occurred.
+
+At such a state, the Subscriber can begin a reconnect sequence to begin subscribing to the new stream once the Publisher has returned from an interrupt with a new broadcast session:
+
+```Swift
+// publisher has unpublished. possibly from background/interrupt.
+if (publisherIsInBackground) {
+  publisherIsDisconnected = true
+  // Begin reconnect sequence...
+  let view = currentView
+  DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+    if(self.subscribeStream != nil) {
+        view?.attach(nil)
+        self.subscribeStream?.delegate = nil;
+        self.subscribeStream!.stop()
+    }
+    self.reconnect()
+  }
+}
+```
+
+[SubscribeTelephonyInterruptTest.swift #29](SubscribeTelephonyInterruptTest.swift#L29)

--- a/R5ProTestbed/Tests/SubscribeTelephonyInterrupt/SubscribeTelephonyInterruptTest.swift
+++ b/R5ProTestbed/Tests/SubscribeTelephonyInterrupt/SubscribeTelephonyInterruptTest.swift
@@ -1,0 +1,45 @@
+//
+//  SubscribeTelephonyInterruptTest.swift
+//  R5ProTestbed
+//
+//  Created by Todd Anderson on 21/02/2019.
+//  Copyright © 2019 Infrared5. All rights reserved.
+//
+
+import UIKit
+import R5Streaming
+
+@objc(SubscribeTelephonyInterruptTest)
+class SubscribeTelephonyInterruptTest: BaseTest {
+    
+    var uiv : UIImageView? = nil
+    
+    override func viewDidAppear(_ animated: Bool) {
+        
+        super.viewDidAppear(animated)
+        
+        setupDefaultR5VideoViewController()
+        
+        let config = getConfig()
+        // Set up the connection and stream
+        let connection = R5Connection(config: config)
+        self.subscribeStream = R5Stream(connection: connection)
+        self.subscribeStream!.delegate = self
+        self.subscribeStream?.client = self;
+        
+        currentView?.attach(subscribeStream)
+        
+        self.subscribeStream!.play(Testbed.getParameter(param: "stream1") as! String)
+        
+        
+    }
+    
+    func onStreamSend(msg : String){
+        NSLog("Received the msg: %@", msg)
+        ALToastView.toast(in: self.view, withText:msg)
+    }
+    
+    
+    
+}
+

--- a/R5ProTestbed/Tests/SubscribeTelephonyInterrupt/SubscribeTelephonyInterruptTest.swift
+++ b/R5ProTestbed/Tests/SubscribeTelephonyInterrupt/SubscribeTelephonyInterruptTest.swift
@@ -12,11 +12,28 @@ import R5Streaming
 @objc(SubscribeTelephonyInterruptTest)
 class SubscribeTelephonyInterruptTest: BaseTest {
     
-    var uiv : UIImageView? = nil
+    var finished = false
+    var publisherIsInBackground = false
+    var publisherIsDisconnected = false
     
-    override func viewDidAppear(_ animated: Bool) {
+    override func onR5StreamStatus(_ stream: R5Stream!, withStatus statusCode: Int32, withMessage msg: String!) {
+        NSLog("Status: %s ", r5_string_for_status(statusCode))
+        let s =  String(format: "Status: %s (%@)",  r5_string_for_status(statusCode), msg)
+        ALToastView.toast(in: self.view, withText:s)
         
-        super.viewDidAppear(animated)
+        if (Int(statusCode) == Int(r5_status_disconnected.rawValue)) {
+            self.cleanup()
+        } else if (Int(statusCode) == Int(r5_status_netstatus.rawValue) && msg == "NetStream.Play.UnpublishNotify") {
+            
+            // publisher has unpublished. possibly from background/interrupt.
+            if (publisherIsInBackground) {
+                publisherIsDisconnected = true
+            }
+            
+        }
+    }
+    
+    func Subscribe(_ name: String) {
         
         setupDefaultR5VideoViewController()
         
@@ -29,17 +46,104 @@ class SubscribeTelephonyInterruptTest: BaseTest {
         
         currentView?.attach(subscribeStream)
         
-        self.subscribeStream!.play(Testbed.getParameter(param: "stream1") as! String)
-        
+        self.subscribeStream!.play(name)
         
     }
     
-    func onStreamSend(msg : String){
-        NSLog("Received the msg: %@", msg)
-        ALToastView.toast(in: self.view, withText:msg)
+    func publisherBackground(msg: String) {
+        NSLog("(publisherBackground) the msg: %@", msg)
+        publisherIsInBackground = true
+        ALToastView.toast(in: self.view, withText:"publishBackground: \(msg)")
     }
     
+    func publisherForeground(msg: String) {
+        NSLog("(publisherForeground) the msg: %@", msg)
+        publisherIsInBackground = false
+        ALToastView.toast(in: self.view, withText:"publisherForeground: \(msg)")
+    }
     
+    func publisherInterrupt(msg: String) {
+        NSLog("(publisherInterrupt) the msg: %@", msg)
+        publisherIsDisconnected = true
+        ALToastView.toast(in: self.view, withText:"publisherInterrupt: \(msg)")
+        
+        // Begin reconnect sequence...
+        reconnect()
+    }
+    
+    func findStreams() {
+        
+        let domain = Testbed.getParameter(param: "host") as! String
+        let app = Testbed.getParameter(param: "context") as! String
+        let urlPath = "http://" + domain + ":5080" + "/" + app + "/streams.jsp"
+        let streamName = Testbed.getParameter(param: "stream1") as! String
+        
+        var request = URLRequest(url: URL(string: urlPath)!)
+        request.addValue("application/json", forHTTPHeaderField: "Accept")
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        
+        let session = URLSession.shared
+        NSLog("Requesting stream list...")
+        
+        session.dataTask(with: request) {data, response, err in
+            
+            if err == nil {
+                //                let resut = data as String
+                do {
+                    NSLog("Stream list received...")
+                    //   Convert our response to a usable NSString
+                    let list = try JSONSerialization.jsonObject(with: data!) as! Array<Dictionary<String, String>>;
+                    
+                    var exists: Bool = false;
+                    for dict:Dictionary<String, String> in list {
+                        if(dict["name"] == streamName){
+                            exists = true;
+                            break;
+                        }
+                    }
+                    DispatchQueue.main.async {
+                        if (exists) {
+                            NSLog("Publisher exists, let's try connecting...")
+                            self.Subscribe(streamName)
+                        }
+                        else {
+                            NSLog("Publisher does not exist.")
+                            self.reconnect()
+                        }
+                    }
+                    
+                }
+                catch let error as NSError {
+                    NSLog(error.localizedFailureReason!)
+                }
+            }
+            else {
+                NSLog(err!.localizedDescription)
+            }
+            
+            }.resume()
+        
+    }
+    
+    func reconnect () {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+            if self.finished {
+                return
+            }
+            self.findStreams()
+        }
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        self.finished = true
+        super.viewWillDisappear(animated)
+    }
+    
+    override func viewDidLoad() {
+        self.finished = false
+        super.viewDidLoad()
+        findStreams()
+    }
     
 }
 

--- a/R5ProTestbed/tests.plist
+++ b/R5ProTestbed/tests.plist
@@ -352,6 +352,17 @@
 			<key>class</key>
 			<string>SubscribeBackgroundTest</string>
 		</dict>
+		<key>subscribe - Telephony Interrupt</key>
+		<dict>
+			<key>description</key>
+			<string>A subscriber example that responds to publisher telephony interrupt.</string>
+			<key>LocalProperties</key>
+			<dict/>
+			<key>name</key>
+			<string>Subscribe - Telephony Interrupt</string>
+			<key>class</key>
+			<string>SubscribeTelephonyInterruptTest</string>
+		</dict>
 		<key>publish - Bandwidth Test</key>
 		<dict>
 			<key>description</key>

--- a/R5ProTestbed/tests.plist
+++ b/R5ProTestbed/tests.plist
@@ -129,6 +129,17 @@
 			<key>class</key>
 			<string>PublishBackgroundTest</string>
 		</dict>
+		<key>publish - Telephony Interrupt</key>
+		<dict>
+			<key>description</key>
+			<string>An example of publishing that responds to telephony-based interrupts.</string>
+			<key>LocalProperties</key>
+			<dict/>
+			<key>name</key>
+			<string>Publish - Telephony Interrupt</string>
+			<key>class</key>
+			<string>PublishTelephonyInterruptTest</string>
+		</dict>
 		<key>publish - Bandwidth Upload Detection</key>
 		<dict>
 			<key>description</key>

--- a/Readme.md
+++ b/Readme.md
@@ -40,8 +40,6 @@ Once you have modified your settings, you can run the application for simulator 
 | *An example of publishing a stream as an authenticated user*   
 | **[Background](R5ProTestbed/Tests/PublishBackground)**
 | *An example that continues to publish audio while the app is in the background*
-| **[Telephony Interrupt](R5ProTestbed/Tests/PublishTelephonyInterrupt)**
-| *An example on `"gracefully"` handling interrupts while broadcasting - such as receiving an declining a phone call**
 | **[Bandwidth Detection - Upload](R5ProTestbed/Tests/BandwidthDetectionUploadOnly)**
 | *An example that tests the upload speed between the device and server before publishing.*   
 | **[Camera Swap](R5ProTestbed/Tests/CameraSwap)**
@@ -66,6 +64,8 @@ Once you have modified your settings, you can run the application for simulator 
 | *The publish portion of the remote call example - sends the remote call.*
 | **[Stream Manager](R5ProTestbed/Tests/PublishStreamManager)**
 | *A publish example that connects with a server cluster using a Stream Manger*
+| **[Telephony Interrupt](R5ProTestbed/Tests/PublishTelephonyInterrupt)**
+| *An example on `"gracefully"` handling interrupts while broadcasting - such as receiving an declining a phone call*
 | **[Two Way](R5ProTestbed/Tests/TwoWay)**
 | *An example of simultaneously publishing while subscribing - allowing a conversation. Includes stream detection and auto-connection.*
 | **[Two Way - Stream Manager](R5ProTestbed/Tests/TwoWayStreamManager)**
@@ -86,8 +86,6 @@ Once you have modified your settings, you can run the application for simulator 
 | *An example of subscribing to a stream as an authenticated user*   
 | **[Background](R5ProTestbed/Tests/SubscribeBackground)**
 | *A subscribing example that can continue when the app moves into the background*
-| **[Telephony Interrupt](R5ProTestbed/Tests/SubscribeTelephonyInterrupt)**
-| *An example on `"gracefully"` responding to interrupts while subscribed to a broadcasting - such as the publisher receiving an declining a phone call**
 | **[Bandwidth Test](R5ProTestbed/Tests/SubscribeBandwidth)**
 | *Detect Insufficient and Sufficient BW flags.  Test on a poor network using a publisher that has high video quality. Video should become sporadic or stop altogether.  The screen will darken when no video is being received.*   
 | **[Bandwidth Detection - Download](R5ProTestbed/Tests/BandwidthDetectionDownloadOnly)**
@@ -106,13 +104,14 @@ Once you have modified your settings, you can run the application for simulator 
 | *The subscribe portion of the remote call example - receives the remote call.*
 | **[Stream Manager](R5ProTestbed/Tests/SubscribeStreamManager)**
 | *A subscribe example that connects with a server cluster using a Stream Manger*
+| **[Telephony Interrupt](R5ProTestbed/Tests/SubscribeTelephonyInterrupt)**
+| *An example on `"gracefully"` responding to interrupts while subscribed to a broadcasting - such as the publisher receiving an declining a phone call*
 | **[Two Streams](R5ProTestbed/Tests/SubscribeTwoStreams)**
 | *An example of subscribing to multiple streams at once, useful for subscribing to a presentation hosted by two people using a Two Way connection.*
 
 ## Notes
 
-1. For some of the above examples you will need two devices (a publisher, and a subscriber). You can also use a web browser to subscribe or publish via Flash, http://your_red5_pro_server_ip:5080/live.
-2. You can see a list of active streams by navigating to http://your_red5_pro_server_ip:5080/live/subscribe.jsp (will need to refresh this page after you have started publishing).
-3. Click on the *flash* link to view the published stream in your browser.
+1. For some of the above examples you will need two devices (a publisher, and a subscriber). You can also use a web browser to subscribe or publish via Flash, `http://<your_red5_pro_server>:5080/live`.
+2. You can see a list of active streams by navigating to `http://your_red5_pro_server:5080/live/subscribe.jsp` (will need to refresh this page after you have started publishing).
 
 [![Analytics](https://ga-beacon.appspot.com/UA-59819838-3/red5pro/streaming-ios?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/Readme.md
+++ b/Readme.md
@@ -32,64 +32,44 @@ Once you have modified your settings, you can run the application for simulator 
 | **[1080p](R5ProTestbed/Tests/Publish)**
 | :-----
 | *A high quality publisher. Note that this is the publish test with a non-default 'bitrate' and camera size values set in tests.plist*
-| -
 | **[ABR](R5ProTestbed/Tests/AdaptiveBitrate)**
 | *A high bitrate publisher with AdaptiveBitrateController*   
-| -
 | **[Aspect Ratio](R5ProTestbed/Tests/PublishAspect)**
 | *A publish example that includes modifying the scale mode of the preview display*
-| -
 | **[Authentication](R5ProTestbed/Tests/PublishAuth)**
 | *An example of publishing a stream as an authenticated user*   
-| -
 | **[Background](R5ProTestbed/Tests/PublishBackground)**
 | *An example that continues to publish audio while the app is in the background*
-| -
 | **[Bandwidth Detection - Upload](R5ProTestbed/Tests/BandwidthDetectionUploadOnly)**
 | *An example that tests the upload speed between the device and server before publishing.*   
-| -
 | **[Camera Swap](R5ProTestbed/Tests/CameraSwap)**
 | *Touch the screen to swap which camera is being used! Verify with flash, android, or other iOS device running subscribe test that camera is swapping properly and no rendering problems occur.*
-| -
 | **[Custom Audio Source](R5ProTestbed/Tests/PublishCustomMic)**
 | *Uses a custom controller to modify audio data for the publisher.*
-| -
 | **[Custom Video Source](R5ProTestbed/Tests/PublishCustomSource)**
 | *Uses a custom controller to supply video data to the publisher.*
-| -
 | **[Device Orientation](R5ProTestbed/Tests/PublishDeviceOrientation)**
 | *Rotate the device to update the orientation of the broadcast stream.  Verify with browser-based players (WebRTC, Flash, HLS), Android, or other iOS device running subscribe test that image is rotating properly and no rendering problems occur.*
-| -
 | **[Image Capture](R5ProTestbed/Tests/PublishStreamImage)**
 | *Touch the publish stream to take a screen shot that is displayed!*
-| -
 | **[High Quality Audio](R5ProTestbed/Tests/PublishHQAudio)**
 | *`R5Microphone.sampleRate` is set to 44100 (the default is 16000).*    
-| -
 | **[Local Record](R5ProTestbed/Tests/PublishLocalRecord)**
 | *A publish example that records stream data locally on the device.*    
-| -
 | **[Mute/Unmute](R5ProTestbed/Tests/PublishPause)**
 | *Touch the screen to toggle between sending Audio & Video, sending just Video, sending just Audio, and sending no Audio or Video. Turning off and on the media sources is considered mute and unmute events, respecitively*
-| -
 | **[Record](R5ProTestbed/Tests/Recorded)**
 | *A publish example that records stream data on the server.*
-| -
 | **[Remote Call](R5ProTestbed/Tests/RemoteCall)**
 | *The publish portion of the remote call example - sends the remote call.*
-| -
 | **[Stream Manager](R5ProTestbed/Tests/PublishStreamManager)**
 | *A publish example that connects with a server cluster using a Stream Manger*
-| -
 | **[Two Way](R5ProTestbed/Tests/TwoWay)**
 | *An example of simultaneously publishing while subscribing - allowing a conversation. Includes stream detection and auto-connection.*
-| -
 | **[Two Way - Stream Manager](R5ProTestbed/Tests/TwoWayStreamManager)**
 | *The two way example, modified to work with a stream manager. Includes stream detection and auto-connection.*
-| -
 | **[Shared Object](R5ProTestbed/Tests/SharedObject)**
 | *An example of sending data and messages between clients through remote shared objects.*
-| -
 | **[Send/Recieve](R5ProTestbed/Tests/SubscribeReceiveSend)**
 | *An example of sending data and messages from a Broadcaster to N-Subscribers.*
 

--- a/Readme.md
+++ b/Readme.md
@@ -40,6 +40,8 @@ Once you have modified your settings, you can run the application for simulator 
 | *An example of publishing a stream as an authenticated user*   
 | **[Background](R5ProTestbed/Tests/PublishBackground)**
 | *An example that continues to publish audio while the app is in the background*
+| **[Telephony Interrupt](R5ProTestbed/Tests/PublishTelephonyInterrupt)**
+| *An example on `"gracefully"` handling interrupts while broadcasting - such as receiving an declining a phone call**
 | **[Bandwidth Detection - Upload](R5ProTestbed/Tests/BandwidthDetectionUploadOnly)**
 | *An example that tests the upload speed between the device and server before publishing.*   
 | **[Camera Swap](R5ProTestbed/Tests/CameraSwap)**
@@ -78,43 +80,32 @@ Once you have modified your settings, you can run the application for simulator 
 | **[Aspect Ratio](R5ProTestbed/Tests/SubscribeAspectRatio)**
 | :----
 | *Change the fill mode of the stream.  scale to fill, scale to fit, scale fill.  Aspect ratio should be maintained on first 2.*  
-| -
 | **[Audio Delay](R5ProTestbed/Tests/SubscribeAudioDelay)**
 | *Captures the raw audio from the stream and delays it with a custom buffer implementation*   
-| -
 | **[Authentication](R5ProTestbed/Tests/SubscribeAuth)**
 | *An example of subscribing to a stream as an authenticated user*   
-| -
 | **[Background](R5ProTestbed/Tests/SubscribeBackground)**
 | *A subscribing example that can continue when the app moves into the background*
-| -
+| **[Telephony Interrupt](R5ProTestbed/Tests/SubscribeTelephonyInterrupt)**
+| *An example on `"gracefully"` responding to interrupts while subscribed to a broadcasting - such as the publisher receiving an declining a phone call**
 | **[Bandwidth Test](R5ProTestbed/Tests/SubscribeBandwidth)**
 | *Detect Insufficient and Sufficient BW flags.  Test on a poor network using a publisher that has high video quality. Video should become sporadic or stop altogether.  The screen will darken when no video is being received.*   
-| -
 | **[Bandwidth Detection - Download](R5ProTestbed/Tests/BandwidthDetectionDownloadOnly)**
 | *An example that tests the download speed between the device and server before subscribing.*  
-| -
 | **[Bandwidth Detection - Dual](R5ProTestbed/Tests/BandwidthDetection)**
 | *An example that tests both the upload and download speeds between the device and server before subscribing.*
-| -
 | **[Cluster](R5ProTestbed/Tests/SubscribeCluster)**
 | *An example of connecting to a cluster server.*
-| -
 | **[Image Capture](R5ProTestbed/Tests/SubscribeStreamImage)**
 | *Touch the subscribe stream to take a screen shot that is displayed!*
-| -
 | **[No View](R5ProTestbed/Tests/SubscribeNoView)**
 | *A proof of using an audio only stream without attaching it to a view.*
-| -
 | **[Reconnect](R5ProTestbed/Tests/SubscribeReconnect)**
 | *An example of reconnecting to a stream on a connection error.*
-| -
 | **[Remote Call](R5ProTestbed/Tests/RemoteCall)**
 | *The subscribe portion of the remote call example - receives the remote call.*
-| -
 | **[Stream Manager](R5ProTestbed/Tests/SubscribeStreamManager)**
 | *A subscribe example that connects with a server cluster using a Stream Manger*
-| -
 | **[Two Streams](R5ProTestbed/Tests/SubscribeTwoStreams)**
 | *An example of subscribing to multiple streams at once, useful for subscribing to a presentation hosted by two people using a Two Way connection.*
 


### PR DESCRIPTION
# New Tests

* *Publish - Telephony Interrupt*
* *Subscribe - Telephony Intrrupt*

These examples demonstrates how to gracefully handle telephony interrupts during a broadcast.

These examples differ form the *Background* tests. The *Background* tests listen for events of user-driven background and foreground actions - such as hitting the Home button and returning to the app.

The *Telephony Interrupt* examples expand on the background with an "interrupt" - such as when an incoming phone call or Facetime occurs during broadcast. In such a scenario, the OS takes control of the broadcasting media (i.e., Camera and Microphone). As a consequence, the broadcast session is in a disconnected state.

The "graceful" handle of such a interrupt state is to:

* [Publisher Side] notify the publisher of the disconnect and request to publish again.
* [Subscriber Side] notify all subscribers using the `send` API of "issues", and start a reconnect sequence for when broadcast comes back.