### PR TITLE
Corrected a static race condition

### DIFF
--- a/R5ProTestbed/DetailViewController.swift
+++ b/R5ProTestbed/DetailViewController.swift
@@ -112,6 +112,9 @@ class DetailViewController: UIViewController, UITextFieldDelegate, UINavigationC
     func configureView() {
         // Update the user interface for the detail item.
         
+        // Access the static shared instance to ensure it's loaded
+        _ = Testbed.sharedInstance
+        
         hostText.text = Testbed.parameters!["host"] as? String
 //        portText.text = Testbed.parameters!["server_port"] as? String
         stream1Text.text = Testbed.parameters!["stream1"] as? String


### PR DESCRIPTION
Initial view was being loaded before static variable was being initiated
Currently only affects latest iOS/XCode combo